### PR TITLE
fix compset for atmospheric N deposition

### DIFF
--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -164,8 +164,8 @@
       <value compset="_BGC%BDRDDMS%VSLSC">CO2_DMSB_VSLSC</value>
       <value compset="_BGC%BPRPDMS%VSLSC%N2OC%NH3C">CO2_DMSA_VSLSC_N2OC_NH3C</value>
       <value compset="_BGC%BDRDDMS%VSLSC%N2OC%NH3C">CO2_DMSB_VSLSC_N2OC_NH3C</value>
-      <value compset="_BGC%BPRPDMS%VSLSC%N2OC%NH3C">CO2_DMSA_VSLSC_N2OC_NH3C_ATMNDEPC</value>
-      <value compset="_BGC%BDRDDMS%VSLSC%N2OC%NH3C">CO2_DMSB_VSLSC_N2OC_NH3C_ATMNDEPC</value>
+      <value compset="_BGC%BPRPDMS%VSLSC%N2OC%NH3C%ATMNDEPC">CO2_DMSA_VSLSC_N2OC_NH3C_ATMNDEPC</value>
+      <value compset="_BGC%BDRDDMS%VSLSC%N2OC%NH3C%ATMNDEPC">CO2_DMSB_VSLSC_N2OC_NH3C_ATMNDEPC</value>
       <value compset="_BGC%DMS">CO2_DMSB</value>
       <value compset="HIST.*_DATM%(QIA|CRU)">CO2A</value>
       <value compset="RCP.*_DATM%(QIA|CRU)" >CO2A</value>


### PR DESCRIPTION
Dear Dirk, I am currently updating the extended nitrogen cycle branch code to be more compatible to the current `master` of iHAMOCC, where a lot of code refactoring had been done and the way, how the namelists are written and how the code is compiled (i.e. removing most pre-processor flags in the iHAMOCC code, enabling configuration at run time). While doing this, I also make/made sure that the NorESM coupling process for the extended nitrogen cycle via cime is/keeps automatized. While doing so, I revisited the cime branch that you were setting up and found a small issue wrt the atmospheric nitrogen deposition, which I fix with this PR. 
